### PR TITLE
add processing for 8 new fields in s3 log files

### DIFF
--- a/s3logparse/s3logparse.py
+++ b/s3logparse/s3logparse.py
@@ -10,7 +10,7 @@ LogLine = namedtuple('LogLine', [
     'error_code', 'bytes_sent', 'object_size', 'total_time',
     'turn_around_time', 'referrer', 'user_agent', 'version_id',
     'host_id', 'signature_version', 'cipher_suite', 'authentication_type',
-    'host_header', 'tls_version', 'access_point_arn', 'acl_required'
+    'host_header', 'tls_version', 'access_point_arn', 'acl_required', 'file_name'
 ])
 
 
@@ -82,10 +82,10 @@ def parse_to_tuples(line_iter):
         yield row
 
 
-def parse_log_lines(line_iter):
+def parse_log_lines(line_iter, file_name=""):
     """
     Parse log lines from an iterable and return LogLine objects with
     appropriate accessors
     """
     for line_tuple in parse_to_tuples(line_iter):
-        yield LogLine(*line_tuple)
+        yield LogLine(*line_tuple, file_name)

--- a/s3logparse/s3logparse.py
+++ b/s3logparse/s3logparse.py
@@ -8,7 +8,9 @@ LogLine = namedtuple('LogLine', [
     'bucket_owner', 'bucket', 'timestamp', 'remote_ip', 'requester',
     'request_id', 'operation', 's3_key', 'request_uri', 'status_code',
     'error_code', 'bytes_sent', 'object_size', 'total_time',
-    'turn_around_time', 'referrer', 'user_agent', 'version_id'
+    'turn_around_time', 'referrer', 'user_agent', 'version_id',
+    'host_id', 'signature_version', 'cipher_suite', 'authentication_type',
+    'host_header', 'tls_version', 'access_point_arn', 'acl_required'
 ])
 
 
@@ -74,7 +76,8 @@ def parse_to_tuples(line_iter):
             shift_int_fields(field_iter, 1),
             shift_string_fields(field_iter, 1),
             shift_int_fields(field_iter, 4),
-            shift_string_fields(field_iter, 3)
+            shift_string_fields(field_iter, 3),
+            shift_string_fields(field_iter, 8)
         ]))
         yield row
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='s3-log-parse',
-    version="0.1.1",
+    version="0.1.2",
     description="Tool for procesing AWS S3 access logs",
     url="https://github.com/cocoonlife/s3-log-parse",
     author="Rob Clarke",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='s3-log-parse',
-    version="0.1.2",
+    version="0.1.3",
     description="Tool for procesing AWS S3 access logs",
     url="https://github.com/cocoonlife/s3-log-parse",
     author="Rob Clarke",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -51,7 +51,8 @@ class LineParserTupleTest(TestCase):
 8eacf8f8d5218e7cd47ef2be mybucket [06/Feb/2014:00:00:38 +0000] 192.0.2.3 79a59\
 df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE \
 REST.GET.VERSIONING - "GET /mybucket?versioning HTTP/1.1" 200 - 113 - 7 - "-" \
-"S3Console/0.4" -'
+"S3Console/0.4" - EXAfPIQ4LEOWDMQM+ey7A9XgZhWnQ2JMAXIFOURb7hASDFGH+Jd1vEXPLEAMa3Km= \
+SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader bucket-name.s3.amazonaws.com TLSv1.2 - -'
         ])
         self.log_fields = next(log_stream)
 
@@ -75,7 +76,7 @@ REST.GET.VERSIONING - "GET /mybucket?versioning HTTP/1.1" 200 - 113 - 7 - "-" \
         """
         int_fields = list(itertools.compress(
             self.log_fields,
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0]
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         ))
         self.assertEqual(
             int_fields,
@@ -88,7 +89,7 @@ REST.GET.VERSIONING - "GET /mybucket?versioning HTTP/1.1" 200 - 113 - 7 - "-" \
         """
         str_fields = itertools.compress(
             self.log_fields,
-            [1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0]
+            [1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0]
         )
         for s in str_fields:
             self.assertIsInstance(s, str)
@@ -99,9 +100,9 @@ REST.GET.VERSIONING - "GET /mybucket?versioning HTTP/1.1" 200 - 113 - 7 - "-" \
         """
         none_fields = list(itertools.compress(
             self.log_fields,
-            [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1]
+            [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1]
         ))
-        self.assertEqual(none_fields, [None] * 4)
+        self.assertEqual(none_fields, [None] * 6)
 
 
 class LogLineParserTests(TestCase):
@@ -115,7 +116,8 @@ class LogLineParserTests(TestCase):
 8eacf8f8d5218e7cd47ef2be mybucket [06/Feb/2014:00:00:38 +0000] 192.0.2.3 79a59\
 df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE \
 REST.GET.VERSIONING - "GET /mybucket?versioning HTTP/1.1" 200 - 113 - 7 - "-" \
-"S3Console/0.4" -'
+"S3Console/0.4" - EXAfPIQ4LEOWDMQM+ey7A9XgZhWnQ2JMAXIFOURb7hASDFGH+Jd1vEXPLEAMa3Km= \
+SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader bucket-name.s3.amazonaws.com TLSv1.2 - -'
         ])
         log_line = next(log_stream)
         self.assertEqual(
@@ -188,5 +190,37 @@ REST.GET.VERSIONING - "GET /mybucket?versioning HTTP/1.1" 200 - 113 - 7 - "-" \
         )
         self.assertEqual(
             log_line.version_id,
+            None
+        )
+        self.assertEqual(
+            log_line.host_id,
+            'EXAfPIQ4LEOWDMQM+ey7A9XgZhWnQ2JMAXIFOURb7hASDFGH+Jd1vEXPLEAMa3Km='
+        )
+        self.assertEqual(
+            log_line.signature_version,
+            'SigV4'
+        )
+        self.assertEqual(
+            log_line.cipher_suite,
+            'ECDHE-RSA-AES128-GCM-SHA256'
+        )
+        self.assertEqual(
+            log_line.authentication_type,
+            'AuthHeader'
+        )
+        self.assertEqual(
+            log_line.host_header,
+            'bucket-name.s3.amazonaws.com'
+        )
+        self.assertEqual(
+            log_line.tls_version,
+            'TLSv1.2'
+        )
+        self.assertEqual(
+            log_line.access_point_arn,
+            None
+        )
+        self.assertEqual(
+            log_line.acl_required,
             None
         )


### PR DESCRIPTION
Add the following 8 new fields to be processed while parsing s3 log files:

Official AWS docs for the [log-record-fields](https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html#log-record-fields)

- host_id
- signature_version
- cipher_suite
- authentication_type
- host_header
- tls_version
- access_point_arn
- acl_required
